### PR TITLE
Better frida installation / android root handling

### DIFF
--- a/pirogue_cli/android/device.py
+++ b/pirogue_cli/android/device.py
@@ -131,7 +131,10 @@ class AndroidDevice:
     def get_frida_client_version(self):
         frida_package = get_install_packages('frida')
         if len(frida_package) != 1:
-            raise Exception('Unable to get the version of Frida installed on the PiRogue')
+            log.warning(
+                'Unable to get the version of Frida installed on the PiRogue, defaulting to latest version.'
+            )
+            return None
         frida_version = frida_package[0].get('version')
         if '~pirogue' in frida_version:
             frida_version = frida_version[0:frida_version.find('~')]
@@ -153,10 +156,10 @@ class AndroidDevice:
 
     def install_latest_frida_server(self):
         frida_client_version = self.get_frida_client_version()
-        log.info(f'⚡ Installing the latest version of frida-server as {self.frida_server_name}...')
+        log.info(f'⚡ Installing the matching version of frida-server as {self.frida_server_name}...')
         with NamedTemporaryFile(mode='wb') as frida_server:
             FridaServer.download_frida_server(self.get_architecture(), frida_server.name, 'android', frida_client_version)
             frida_server.seek(0)
             self.__adb_push(frida_server.name, self.frida_server_install_dir)
             self.__adb_shell(f'chmod +x {self.frida_server_install_dir}')
-            log.info('⚡ Latest version of frida-server successfully installed...')
+            log.info('⚡ Matching version of frida-server successfully installed...')

--- a/pirogue_cli/system/apt.py
+++ b/pirogue_cli/system/apt.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 import subprocess
 from typing import List
 
@@ -9,6 +10,10 @@ log = logging.getLogger(__name__)
 
 
 def get_install_packages(pattern: str) -> List[dict]:
+    if shutil.which('dpkg-query') is None:
+        # Not running on Raspbian/Ubuntu/Debian
+        return []
+
     cmd = 'dpkg-query --showformat=\'${Status}\t${Package}\t${Version}\t${Homepage}\n\' -W "%s"' % pattern
     packages = []
     try:


### PR DESCRIPTION
Hi,

Here are two small fixes to:
* Make frida version detection not fail on non-apt-based distributions (simply ignore check and fetch the latest frida client available in this case).
* Better handle smartphones without root debugging enabled, which was resulted in non verbose errors.

Best,